### PR TITLE
Add Modifications in Image Class to python 3

### DIFF
--- a/anchor/anchor_image.py
+++ b/anchor/anchor_image.py
@@ -37,7 +37,7 @@ class AnchorImage(object):
                     out = []
                     for i, path in enumerate(paths):
                         if i % 100 == 0:
-                            print i
+                            print(i)
                         out.append(transform_img(path))
                     return out
                 transform_img_fn = transform_imgs
@@ -62,7 +62,7 @@ class AnchorImage(object):
         n_features = len(features)
 
         true_label = np.argmax(classifier_fn(np.expand_dims(image, 0))[0])
-        print 'True pred', true_label
+        print ('True pred', true_label)
 
         def lime_sample_fn(num_samples, batch_size=50):
             # data = np.random.randint(0, 2, num_samples * n_features).reshape(


### PR DESCRIPTION
When running the anchor image in the jupyter notebook with python 3 I realized this inconsistency to run in python 3, so with these small modifications worked perfectly, if you needed such modifications were only accurate in the image class.