### PR TITLE
Add check for None categorical_names

### DIFF
--- a/anchor/anchor_tabular.py
+++ b/anchor/anchor_tabular.py
@@ -45,6 +45,8 @@ class AnchorTabularExplainer(object):
                 n_values=n_values)
             self.encoder.fit(data)
             self.categorical_features = self.encoder.categorical_features
+        else:
+            categorical_names = {}
         if len(ordinal_features) == 0:
             self.ordinal_features = [x for x in range(len(feature_names)) if x not in self.categorical_features]
         self.feature_names = feature_names


### PR DESCRIPTION
This PR addressed issue #3 and implements the [proposed workaround](https://github.com/marcotcr/anchor/issues/3#issuecomment-404757239).

I'm currently trying to apply anchor to a proprietary tabular dataset with only numerical features dataset in a production setting, hence this fix would be very helpful.

I tried testing on the Wisconsin breast cancer dataset, another dataset with only numerical features, and the `AnchorTabularExplainer` seems to work:

```
In [1]: from sklearn import datasets                                                                                                                                                                                                                                     
from s
In [2]: from sklearn.model_selection import train_test_split                                                                                                                                                                                                             

In [3]: from anchor.anchor_tabular import AnchorTabularExplainer                                                                                                                                                                                                         

In [4]: dataset = datasets.load_breast_cancer()                                                                                                                                                                                                                          

In [5]: X, y = dataset['data'], dataset['target']                                                                                                                                                                                                                        

In [6]: X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)                                                                                                                                                                                         

In [7]: explainer = AnchorTabularExplainer(dataset.target_names, dataset.feature_names, dataset.data)                                                                                                                                                                    

In [8]: explainer.fit(X_train, y_train, X_test, y_test)                                                                                                                                                                                                                  

In [9]: from sklearn.ensemble import RandomForestClassifier                                                                                                                                                                                                              

In [10]: clf = RandomForestClassifier()                                                                                                                                                                                                                                  

In [11]: clf.fit(X_train, y_train)                                                                                                                                                                                                                                       

Out[11]: 
RandomForestClassifier(bootstrap=True, class_weight=None, criterion='gini',
                       max_depth=None, max_features='auto', max_leaf_nodes=None,
                       min_impurity_decrease=0.0, min_impurity_split=None,
                       min_samples_leaf=1, min_samples_split=2,
                       min_weight_fraction_leaf=0.0, n_estimators=10,
                       n_jobs=None, oob_score=False, random_state=None,
                       verbose=0, warm_start=False)

In [12]: predict_fn = lambda x: clf.predict(explainer.encoder.transform(x))                                                                                                                                                                                              

In [13]: idx = 0                                                                                                                                                                                                                                                         

In [14]: print('Prediction: ', explainer.class_names[predict_fn(X_test[idx].reshape(1, -1))[0]])                                                                                                                                                                         
Prediction:  malignant

In [15]: exp = explainer.explain_instance(X_test[idx], clf.predict, threshold=0.95)                                                                                                                                                                                      

In [16]: print('Anchor: %s' % (' AND '.join(exp.names())))                                                                                                                                                                                                               
Anchor: worst perimeter > 125.25 AND mean concavity > 0.13

In [17]: print('Precision: %.2f' % exp.precision())                                                                                                                                                                                                                      
Precision: 1.00

In [18]: print('Coverage: %.2f' % exp.coverage())                                                                                                                                                                                                                        
Coverage: 0.19
```