### PR TITLE
Check if words have a vector, not just if they are in the spacy models vocabulary 

### DIFF
--- a/anchor/anchor_text.py
+++ b/anchor/anchor_text.py
@@ -28,8 +28,8 @@ class TextGenerator(object):
         self.url = url
         if url is None:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            self.bert_tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-cased')
-            self.bert = DistilBertForMaskedLM.from_pretrained('distilbert-base-cased')
+            self.bert_tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-german-cased')
+            self.bert = DistilBertForMaskedLM.from_pretrained('distilbert-base-german-cased')
             self.bert.to(self.device)
             self.bert.eval()
 

--- a/anchor/anchor_text.py
+++ b/anchor/anchor_text.py
@@ -28,8 +28,8 @@ class TextGenerator(object):
         self.url = url
         if url is None:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            self.bert_tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-german-cased')
-            self.bert = DistilBertForMaskedLM.from_pretrained('distilbert-base-german-cased')
+            self.bert_tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-cased')
+            self.bert = DistilBertForMaskedLM.from_pretrained('distilbert-base-cased')
             self.bert.to(self.device)
             self.bert.eval()
 

--- a/anchor/utils.py
+++ b/anchor/utils.py
@@ -327,6 +327,8 @@ class Neighbors:
         if word not in self.n:
             if word not in self.nlp.vocab.strings:
                 self.n[word] = []
+            elif not self.nlp.vocab[word].has_vector:
+                self.n[word] = []
             else:
                 word = self.nlp.vocab[word]
                 queries = [w for w in self.to_check


### PR DESCRIPTION
When working with the english spacy model (en_core_web_lg), it is sufficient to check whether the word is contained in the vocabulary, since every word in the vocabulary has a vector. Unfortunately, this does not apply to all spacy models (e.g. de_core_news_md), so explicitly checking if the word has a vector would be more robust imo.  