### PR TITLE
bugfix: avoid truncation of input string (Issue #75)

### DIFF
--- a/anchor/anchor_base.py
+++ b/anchor/anchor_base.py
@@ -170,6 +170,13 @@ class AnchorBaseBeam(object):
             current_idx = state['current_idx']
             # idxs = range(state['data'].shape[0], state['data'].shape[0] + n)
             idxs = range(current_idx, current_idx + n)
+
+            if '<U' in str(raw_data.dtype):
+                # String types: convert types to maximum length to avoid truncation. E.g., '<U308', '<U290' -> '<U308'
+                max_dtype = max(str(state['raw_data'].dtype), str(raw_data.dtype))
+                state['raw_data'] = state['raw_data'].astype(max_dtype)
+                raw_data = raw_data.astype(max_dtype)
+
             state['t_idx'][t].update(idxs)
             state['t_nsamples'][t] += n
             state['t_positives'][t] += labels.sum()

--- a/anchor/anchor_base.py
+++ b/anchor/anchor_base.py
@@ -172,7 +172,8 @@ class AnchorBaseBeam(object):
             idxs = range(current_idx, current_idx + n)
 
             if '<U' in str(raw_data.dtype):
-                # String types: convert types to maximum length to avoid truncation. E.g., '<U308', '<U290' -> '<U308'
+                # String types: make sure both string types are of maximum length 
+                # to avoid string truncation. E.g., '<U308', '<U290' -> '<U308'
                 max_dtype = max(str(state['raw_data'].dtype), str(raw_data.dtype))
                 state['raw_data'] = state['raw_data'].astype(max_dtype)
                 raw_data = raw_data.astype(max_dtype)


### PR DESCRIPTION
This commit fixes an issue in anchor_base.py where input strings (provided by anchor_text.py) are truncated. The issue is due to the following [line](https://github.com/gkaramanolakis/anchor/blob/e66243500b835a3c8e1dff409acd8c20bdd852c6/anchor/anchor_base.py#L184) in anchor_base.py: 

`state['raw_data'][idxs] = raw_data`

As an example, when the type of raw_data is '<U308' (i.e., 308-character unicode strings) and the type of state['raw_data'] is '<U290' (i.e., 290-character unicode strings), then the above line of code leads to the truncation of raw_data to 290-character strings, thus leading to issues such as the one reported in Issue #75. 

This commit addresses the above issue by converting the string types to the type of maximum length. 